### PR TITLE
Use configured repositories from the sbt build

### DIFF
--- a/interfaces/migrate/src/main/java/migrate/interfaces/Migrate.java
+++ b/interfaces/migrate/src/main/java/migrate/interfaces/Migrate.java
@@ -4,6 +4,7 @@ import coursierapi.Dependency;
 import coursierapi.Fetch;
 import coursierapi.ResolutionParams;
 import coursierapi.ScalaVersion;
+import coursierapi.MavenRepository;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
@@ -28,7 +29,7 @@ public interface Migrate {
                  Path baseDirectory);
     
     MigratedScalacOptions migrateScalacOption(List<String> scala3CompilerOptions);
-    MigratedLibs migrateLibs(List<Lib> libs);
+    MigratedLibs migrateLibs(List<Lib> libs, List<MavenRepository> repositories);
 
     void migrateSyntax(List<Path> unmanagedSources,
                        Path targetRoot,

--- a/interfaces/migrate/src/main/java/migrate/interfaces/Migrate.java
+++ b/interfaces/migrate/src/main/java/migrate/interfaces/Migrate.java
@@ -29,7 +29,7 @@ public interface Migrate {
                  Path baseDirectory);
     
     MigratedScalacOptions migrateScalacOption(List<String> scala3CompilerOptions);
-    MigratedLibs migrateLibs(List<Lib> libs, List<MavenRepository> repositories);
+    MigratedLibs migrateLibs(List<Lib> libs, List<String> repositories);
 
     void migrateSyntax(List<Path> unmanagedSources,
                        Path targetRoot,

--- a/interfaces/migrate/src/main/java/migrate/interfaces/Migrate.java
+++ b/interfaces/migrate/src/main/java/migrate/interfaces/Migrate.java
@@ -4,7 +4,6 @@ import coursierapi.Dependency;
 import coursierapi.Fetch;
 import coursierapi.ResolutionParams;
 import coursierapi.ScalaVersion;
-import coursierapi.MavenRepository;
 
 import java.io.File;
 import java.lang.reflect.Constructor;

--- a/migrate/src/main/scala/migrate/LibraryMigration.scala
+++ b/migrate/src/main/scala/migrate/LibraryMigration.scala
@@ -3,17 +3,15 @@ package migrate
 import migrate.buildinfo.BuildInfo
 import migrate.interfaces.MigratedLib
 import migrate.interfaces.MigratedLibs
-import migrate.internal.{
-  CrossCompatibleLibrary,
-  CrossVersion,
-  IncompatibleLibrary,
-  InitialLib,
-  IntegratedPlugin,
-  Repository,
-  UnclassifiedLibrary,
-  UpdatedVersion,
-  ValidLibrary
-}
+import migrate.internal.CrossCompatibleLibrary
+import migrate.internal.CrossVersion
+import migrate.internal.IncompatibleLibrary
+import migrate.internal.InitialLib
+import migrate.internal.IntegratedPlugin
+import migrate.internal.Repository
+import migrate.internal.UnclassifiedLibrary
+import migrate.internal.UpdatedVersion
+import migrate.internal.ValidLibrary
 import migrate.utils.CoursierHelper
 
 object LibraryMigration {

--- a/migrate/src/main/scala/migrate/LibraryMigration.scala
+++ b/migrate/src/main/scala/migrate/LibraryMigration.scala
@@ -3,20 +3,23 @@ package migrate
 import migrate.buildinfo.BuildInfo
 import migrate.interfaces.MigratedLib
 import migrate.interfaces.MigratedLibs
-import migrate.internal.CrossCompatibleLibrary
-import migrate.internal.CrossVersion
-import migrate.internal.IncompatibleLibrary
-import migrate.internal.InitialLib
-import migrate.internal.IntegratedPlugin
-import migrate.internal.UnclassifiedLibrary
-import migrate.internal.UpdatedVersion
-import migrate.internal.ValidLibrary
+import migrate.internal.{
+  CrossCompatibleLibrary,
+  CrossVersion,
+  IncompatibleLibrary,
+  InitialLib,
+  IntegratedPlugin,
+  Repository,
+  UnclassifiedLibrary,
+  UpdatedVersion,
+  ValidLibrary
+}
 import migrate.utils.CoursierHelper
 
 object LibraryMigration {
-  def migrateLibs(libs: Seq[InitialLib]): MigratedLibs = {
+  def migrateLibs(libs: Seq[InitialLib], repositories: Seq[Repository]): MigratedLibs = {
     val filteredLibs = libs.filterNot(l => InitialLib.migrationFilter.contains((l.organization, l.name)))
-    val migratedLibs = filteredLibs.map(migrateLib)
+    val migratedLibs = filteredLibs.map(migrateLib(_, repositories))
 
     val validLibs                = migratedLibs.collect { case l: ValidLibrary => l }.toArray[MigratedLib]
     val updatedVersions          = migratedLibs.collect { case l: UpdatedVersion => l }.toArray[MigratedLib]
@@ -34,44 +37,44 @@ object LibraryMigration {
       incompatibleLibraries)
   }
 
-  def migrateLib(lib: InitialLib): MigratedLib =
-    if (lib.isCompilerPlugin) migrateCompilerPlugin(lib)
-    else migrateRegularLib(lib)
+  def migrateLib(lib: InitialLib, repositories: Seq[Repository]): MigratedLib =
+    if (lib.isCompilerPlugin) migrateCompilerPlugin(lib, repositories)
+    else migrateRegularLib(lib, repositories)
 
-  def migrateRegularLib(lib: InitialLib): MigratedLib =
+  def migrateRegularLib(lib: InitialLib, repositories: Seq[Repository]): MigratedLib =
     lib.crossVersion match {
-      case CrossVersion.Disabled       => tryParseBinaryVersionAndMigrate(lib)
+      case CrossVersion.Disabled       => tryParseBinaryVersionAndMigrate(lib, repositories)
       case _: CrossVersion.For2_13Use3 => ValidLibrary(lib)
       case _: CrossVersion.For3Use2_13 => ValidLibrary(lib)
-      case _: CrossVersion.Binary      => migrateBinaryVersion(lib)
-      case _: CrossVersion.Full        => migrateFullCrossVersion(lib)
-      case CrossVersion.Patch          => migrateFullCrossVersion(lib)
+      case _: CrossVersion.Binary      => migrateBinaryVersion(lib, repositories)
+      case _: CrossVersion.Full        => migrateFullCrossVersion(lib, repositories)
+      case CrossVersion.Patch          => migrateFullCrossVersion(lib, repositories)
       case CrossVersion.Constant("2.13") =>
-        migrateBinaryVersion(lib.copy(crossVersion = CrossVersion.Binary("", "")))
+        migrateBinaryVersion(lib.copy(crossVersion = CrossVersion.Binary("", "")), repositories)
       case CrossVersion.Constant(s"2.13.$_") =>
-        migrateFullCrossVersion(lib.copy(crossVersion = CrossVersion.Binary("", "")))
+        migrateFullCrossVersion(lib.copy(crossVersion = CrossVersion.Binary("", "")), repositories)
       case cv: CrossVersion.Constant => UnclassifiedLibrary(lib, s"Unsupported CrossVersion.$cv")
     }
 
-  private def tryParseBinaryVersionAndMigrate(lib: InitialLib): MigratedLib =
+  private def tryParseBinaryVersionAndMigrate(lib: InitialLib, repositories: Seq[Repository]): MigratedLib =
     lib.name.split("_").toList match {
       case name :: suffix :: Nil =>
         suffix match {
           case "2.13" =>
             val newLib = lib.copy(name = name, crossVersion = CrossVersion.Binary("", ""))
-            migrateBinaryVersion(newLib)
+            migrateBinaryVersion(newLib, repositories)
           case s"2.13.$_" =>
             val newLib = lib.copy(name = name, crossVersion = CrossVersion.Full("", ""))
-            migrateFullCrossVersion(newLib)
+            migrateFullCrossVersion(newLib, repositories)
           case _ => ValidLibrary(lib)
         }
       case _ => ValidLibrary(lib)
     }
 
-  private def migrateBinaryVersion(lib: InitialLib): MigratedLib =
-    if (CoursierHelper.isCompatible(lib, "3")) ValidLibrary(lib)
+  private def migrateBinaryVersion(lib: InitialLib, repositories: Seq[Repository]): MigratedLib =
+    if (CoursierHelper.isCompatible(lib, "3", repositories)) ValidLibrary(lib)
     else {
-      CoursierHelper.findNewerVersions(lib, "3").toList match {
+      CoursierHelper.findNewerVersions(lib, "3", repositories).toList match {
         case Nil =>
           if (lib.isCompilerPlugin) IncompatibleLibrary(lib, "Compiler Plugin")
           else if (InitialLib.macroLibraries.contains(lib.organization, lib.name))
@@ -81,8 +84,8 @@ object LibraryMigration {
       }
     }
 
-  private def migrateFullCrossVersion(lib: InitialLib): MigratedLib =
-    CoursierHelper.findNewerVersions(lib, BuildInfo.scala3Version) match {
+  private def migrateFullCrossVersion(lib: InitialLib, repositories: Seq[Repository]): MigratedLib =
+    CoursierHelper.findNewerVersions(lib, BuildInfo.scala3Version, repositories) match {
       case Nil =>
         val reason =
           if (lib.isCompilerPlugin) "Compiler plugin"
@@ -91,9 +94,9 @@ object LibraryMigration {
       case newerVersions => UpdatedVersion(lib, newerVersions)
     }
 
-  private def migrateCompilerPlugin(lib: InitialLib): MigratedLib =
+  private def migrateCompilerPlugin(lib: InitialLib, repositories: Seq[Repository]): MigratedLib =
     (lib.organization, lib.name) match {
       case ("org.typelevel", "kind-projector") => IntegratedPlugin(lib, "-Ykind-projector")
-      case (_, _)                              => migrateRegularLib(lib)
+      case (_, _)                              => migrateRegularLib(lib, repositories)
     }
 }

--- a/migrate/src/main/scala/migrate/interfaces/MigrateImpl.scala
+++ b/migrate/src/main/scala/migrate/interfaces/MigrateImpl.scala
@@ -1,16 +1,14 @@
 package migrate.interfaces
 
+import coursierapi.MavenRepository
+
 import java.nio.file.Path
 import java.{util => jutil}
-
 import scala.jdk.CollectionConverters._
-
 import migrate.LibraryMigration
 import migrate.Scala3Migrate
 import migrate.ScalacOptionsMigration
-import migrate.internal.AbsolutePath
-import migrate.internal.Classpath
-import migrate.internal.InitialLib
+import migrate.internal.{AbsolutePath, Classpath, InitialLib, Repository}
 import migrate.utils.ScalaExtensions._
 import migrate.utils.ScalafixService
 
@@ -58,9 +56,10 @@ final class MigrateImpl(logger: Logger) extends Migrate {
   override def migrateScalacOption(scalacOptions: jutil.List[String]): MigratedScalacOptions =
     ScalacOptionsMigration.migrate(scalacOptions.asScala.toSeq)
 
-  override def migrateLibs(libs: jutil.List[Lib]): MigratedLibs = {
+  override def migrateLibs(libs: jutil.List[Lib], repositories: jutil.List[MavenRepository]): MigratedLibs = {
     val initialLibs = libs.asScala.map(InitialLib.apply).toSeq
-    LibraryMigration.migrateLibs(initialLibs)
+    val initialRepos = repositories.asScala.map(x=> Repository(x.getBase)).toSeq
+    LibraryMigration.migrateLibs(initialLibs, initialRepos)
   }
 
   override def migrateSyntax(

--- a/migrate/src/main/scala/migrate/interfaces/MigrateImpl.scala
+++ b/migrate/src/main/scala/migrate/interfaces/MigrateImpl.scala
@@ -1,14 +1,17 @@
 package migrate.interfaces
 
-import coursierapi.MavenRepository
-
 import java.nio.file.Path
 import java.{util => jutil}
+
 import scala.jdk.CollectionConverters._
+
 import migrate.LibraryMigration
 import migrate.Scala3Migrate
 import migrate.ScalacOptionsMigration
-import migrate.internal.{AbsolutePath, Classpath, InitialLib, Repository}
+import migrate.internal.AbsolutePath
+import migrate.internal.Classpath
+import migrate.internal.InitialLib
+import migrate.internal.Repository
 import migrate.utils.ScalaExtensions._
 import migrate.utils.ScalafixService
 

--- a/migrate/src/main/scala/migrate/interfaces/MigrateImpl.scala
+++ b/migrate/src/main/scala/migrate/interfaces/MigrateImpl.scala
@@ -56,9 +56,9 @@ final class MigrateImpl(logger: Logger) extends Migrate {
   override def migrateScalacOption(scalacOptions: jutil.List[String]): MigratedScalacOptions =
     ScalacOptionsMigration.migrate(scalacOptions.asScala.toSeq)
 
-  override def migrateLibs(libs: jutil.List[Lib], repositories: jutil.List[MavenRepository]): MigratedLibs = {
-    val initialLibs = libs.asScala.map(InitialLib.apply).toSeq
-    val initialRepos = repositories.asScala.map(x=> Repository(x.getBase)).toSeq
+  override def migrateLibs(libs: jutil.List[Lib], repositories: jutil.List[String]): MigratedLibs = {
+    val initialLibs  = libs.asScala.map(InitialLib.apply).toSeq
+    val initialRepos = repositories.asScala.map(Repository).toSeq
     LibraryMigration.migrateLibs(initialLibs, initialRepos)
   }
 

--- a/migrate/src/main/scala/migrate/internal/Repository.scala
+++ b/migrate/src/main/scala/migrate/internal/Repository.scala
@@ -1,5 +1,5 @@
 package migrate.internal
 
 
-case class Repository (url:String)
+case class Repository(url:String)
 

--- a/migrate/src/main/scala/migrate/internal/Repository.scala
+++ b/migrate/src/main/scala/migrate/internal/Repository.scala
@@ -1,5 +1,3 @@
 package migrate.internal
 
-
 case class Repository(url:String)
-

--- a/migrate/src/main/scala/migrate/internal/Repository.scala
+++ b/migrate/src/main/scala/migrate/internal/Repository.scala
@@ -1,0 +1,5 @@
+package migrate.internal
+
+
+case class Repository (url:String)
+

--- a/migrate/src/main/scala/migrate/utils/CoursierHelper.scala
+++ b/migrate/src/main/scala/migrate/utils/CoursierHelper.scala
@@ -1,8 +1,10 @@
 package migrate.utils
 
 import scala.concurrent.ExecutionContext
-import coursier.maven.MavenRepository
-import migrate.internal.{InitialLib, Repository}
+
+import coursier.MavenRepository
+import migrate.internal.InitialLib
+import migrate.internal.Repository
 
 object CoursierHelper {
 

--- a/migrate/src/main/scala/migrate/utils/CoursierHelper.scala
+++ b/migrate/src/main/scala/migrate/utils/CoursierHelper.scala
@@ -1,33 +1,32 @@
 package migrate.utils
 
 import scala.concurrent.ExecutionContext
-
-import coursier.Repositories
-import migrate.internal.InitialLib
+import coursier.maven.MavenRepository
+import migrate.internal.{InitialLib, Repository}
 
 object CoursierHelper {
 
-  def findNewerVersions(lib: InitialLib, scalaVersion: String): Seq[String] = {
-    val versions = findAllVersions(lib, scalaVersion)
+  def findNewerVersions(lib: InitialLib, scalaVersion: String, repositories: Seq[Repository]): Seq[String] = {
+    val versions = findAllVersions(lib, scalaVersion, repositories)
     dropOlderVersions(lib.version, versions)
   }
 
-  def isCompatible(lib: InitialLib, scalaVersion: String): Boolean = {
+  def isCompatible(lib: InitialLib, scalaVersion: String, repositories: Seq[Repository]): Boolean = {
     val binaryVersion = lib.crossVersion.prefix + scalaVersion + lib.crossVersion.suffix
     val libString     = s"${lib.organization}:${lib.name}_$binaryVersion:${lib.version}"
-    coursierComplete(libString).nonEmpty
+    coursierComplete(libString, repositories).nonEmpty
   }
 
-  private def findAllVersions(lib: InitialLib, scalaVersion: String): Seq[String] = {
+  private def findAllVersions(lib: InitialLib, scalaVersion: String, repositories: Seq[Repository]): Seq[String] = {
     val binaryVersion = lib.crossVersion.prefix + scalaVersion + lib.crossVersion.suffix
     val libString     = s"${lib.organization}:${lib.name}_${binaryVersion}:"
-    coursierComplete(libString)
+    coursierComplete(libString, repositories)
   }
 
-  private def coursierComplete(input: String): Seq[String] = {
+  private def coursierComplete(input: String, repositories: Seq[Repository]): Seq[String] = {
     val res = coursier.complete
       .Complete()
-      .withRepositories(Seq(Repositories.central))
+      .withRepositories(repositories.map(r => MavenRepository(r.url)))
       .withInput(input)
       .result()
       .unsafeRun()(ExecutionContext.global)

--- a/migrate/src/test/scala/migrate/LibraryMigrationSuite.scala
+++ b/migrate/src/test/scala/migrate/LibraryMigrationSuite.scala
@@ -72,15 +72,16 @@ class LibraryMigrationSuite extends AnyFunSuiteLike {
     assert(version.head.toString == "2.6.1")
   }
 
-  test("not available in scala 3 with default repository") {
+  test("only available in an earlier version in maven central repository") {
     val migrated = LibraryMigration.migrateLib(akka, defaultRepositories)
     assert(migrated.isInstanceOf[UpdatedVersion])
-    val version = migrated.asInstanceOf[UpdatedVersion].versions
-    assert(version.contains("2.6.17") )
+    val versions = migrated.asInstanceOf[UpdatedVersion].versions
+    assert(versions.last == "2.9.0-M2", "The last version published to Maven Central was 2.9.0-M2")
   }
 
-  test("available in scala 3 in another repository ") {
-    val migrated = LibraryMigration.migrateLib(akka, defaultRepositories :+ Repository("https://repo.akka.io/maven"))
+  test("available in scala 3 in another repository") {
+    val repositories = defaultRepositories :+ Repository("https://repo.akka.io/maven")
+    val migrated     = LibraryMigration.migrateLib(akka, repositories)
     assert(migrated.isInstanceOf[ValidLibrary])
   }
 

--- a/migrate/src/test/scala/migrate/LibraryMigrationSuite.scala
+++ b/migrate/src/test/scala/migrate/LibraryMigrationSuite.scala
@@ -1,13 +1,15 @@
 package migrate
 
 import scala.Console._
-
-import migrate.internal.CrossCompatibleLibrary
-import migrate.internal.CrossVersion
-import migrate.internal.IncompatibleLibrary
-import migrate.internal.InitialLib
-import migrate.internal.UpdatedVersion
-import migrate.internal.ValidLibrary
+import migrate.internal.{
+  CrossCompatibleLibrary,
+  CrossVersion,
+  IncompatibleLibrary,
+  InitialLib,
+  Repository,
+  UpdatedVersion,
+  ValidLibrary
+}
 import org.scalatest.funsuite.AnyFunSuiteLike
 
 class LibraryMigrationSuite extends AnyFunSuiteLike {
@@ -16,6 +18,7 @@ class LibraryMigrationSuite extends AnyFunSuiteLike {
   val fullJvm: CrossVersion.Full     = CrossVersion.Full("", "")
   val pluginConfig: Some[String]     = Some("plugin->default(compile)")
 
+  val akka: InitialLib             = InitialLib("com.typesafe.akka:akka-actor:2.9.4", binaryJvm)
   val cats: InitialLib             = InitialLib("org.typelevel:cats-core:2.4.0", binaryJvm)
   val cats213: InitialLib          = InitialLib("org.typelevel:cats-core_2.13:2.4.0", CrossVersion.Disabled)
   val opentelemetry: InitialLib    = InitialLib("io.opentelemetry:opentelemetry-api:0.7.1", CrossVersion.Disabled)
@@ -31,8 +34,10 @@ class LibraryMigrationSuite extends AnyFunSuiteLike {
   val domtypes: InitialLib    = InitialLib("com.raquo:domtypes:0.14.3", binaryJs)
   val domutils: InitialLib    = InitialLib("com.raquo:domtestutils:0.14.7", binaryJs)
 
+  val defaultRepositories: Seq[Repository] = Seq(Repository("https://repo1.maven.org/maven2"))
+
   test("Integrated compiler plugin: kind projector") {
-    val migrated  = LibraryMigration.migrateLib(kindProjector)
+    val migrated  = LibraryMigration.migrateLib(kindProjector, defaultRepositories)
     val formatted = migrated.formatted
     val expected =
       s"""addCompilerPlugin(("org.typelevel" %% "kind-projector" % "0.12.0").cross(CrossVersion.full))""" +
@@ -42,52 +47,64 @@ class LibraryMigrationSuite extends AnyFunSuiteLike {
   }
 
   test("Incompatible compiler plugin: better monadic for") {
-    val migrated  = LibraryMigration.migrateLib(betterMonadicFor)
+    val migrated  = LibraryMigration.migrateLib(betterMonadicFor, defaultRepositories)
     val formatted = migrated.formatted
     val expected  = s"""addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1") $RED(Compiler Plugin)$RESET"""
     assert(formatted == expected)
   }
 
   test("Java lib") {
-    val migrated = LibraryMigration.migrateLib(opentelemetry)
+    val migrated = LibraryMigration.migrateLib(opentelemetry, defaultRepositories)
     val expected = ValidLibrary(opentelemetry)
     assert(migrated == expected)
   }
 
   test("Java lib 2") {
-    val migrated = LibraryMigration.migrateLib(javaLib2)
+    val migrated = LibraryMigration.migrateLib(javaLib2, defaultRepositories)
     val expected = ValidLibrary(javaLib2)
     assert(migrated == expected)
   }
 
   test("Available in scala 3") {
-    val migrated = LibraryMigration.migrateLib(cats)
+    val migrated = LibraryMigration.migrateLib(cats, defaultRepositories)
     assert(migrated.isInstanceOf[UpdatedVersion])
     val version = migrated.asInstanceOf[UpdatedVersion].versions
     assert(version.head.toString == "2.6.1")
   }
 
+  test("not available in scala 3 with default repository") {
+    val migrated = LibraryMigration.migrateLib(akka, defaultRepositories)
+    assert(migrated.isInstanceOf[UpdatedVersion])
+    val version = migrated.asInstanceOf[UpdatedVersion].versions
+    assert(version.contains("2.6.17") )
+  }
+
+  test("available in scala 3 in another repository ") {
+    val migrated = LibraryMigration.migrateLib(akka, defaultRepositories :+ Repository("https://repo.akka.io/maven"))
+    assert(migrated.isInstanceOf[ValidLibrary])
+  }
+
   test("CrossVersion.Disabled to CrossVersion.Binary") {
-    val migrated = LibraryMigration.migrateLib(cats213)
+    val migrated = LibraryMigration.migrateLib(cats213, defaultRepositories)
     assert(migrated.isInstanceOf[UpdatedVersion])
     val updatedVersion = migrated.asInstanceOf[UpdatedVersion]
     assert(updatedVersion.versions.head.toString == "2.6.1")
     assert(updatedVersion.lib == cats)
   }
   test("Don't show older version") {
-    val migrated = LibraryMigration.migrateLib(collectionCompat)
+    val migrated = LibraryMigration.migrateLib(collectionCompat, defaultRepositories)
     assert(migrated.isInstanceOf[UpdatedVersion])
     val updatedVersions = migrated.asInstanceOf[UpdatedVersion].versions
     assert(!updatedVersions.contains("2.3.2"))
   }
   test("Cross compatible lib") {
-    val migrated = LibraryMigration.migrateLib(scalafix)
+    val migrated = LibraryMigration.migrateLib(scalafix, defaultRepositories)
     val expected = CrossCompatibleLibrary(scalafix)
     assert(migrated == expected)
   }
   // Warning: this test may change if the lib is ported to scala 3
   test("Incompatible because macro lib") {
-    val migrated = LibraryMigration.migrateLib(macroLib)
+    val migrated = LibraryMigration.migrateLib(macroLib, defaultRepositories)
     val expected = IncompatibleLibrary(macroLib, "Macro Library")
     assert(migrated == expected)
   }
@@ -95,7 +112,7 @@ class LibraryMigrationSuite extends AnyFunSuiteLike {
   test("Filtered out libs") {
     val scalaLib     = InitialLib("org.scala-lang:scala-library:2.13.13", CrossVersion.Disabled)
     val scalajs      = InitialLib("org.scala-js:scalajs-compiler:1.5.0", CrossVersion.Disabled)
-    val migratedLibs = LibraryMigration.migrateLibs(Seq(scalaLib, scalajs))
+    val migratedLibs = LibraryMigration.migrateLibs(Seq(scalaLib, scalajs), defaultRepositories)
     assert(migratedLibs.getValidLibraries.isEmpty)
     assert(migratedLibs.getUpdatedVersions.isEmpty)
     assert(migratedLibs.getCrossCompatibleLibraries.isEmpty)
@@ -112,7 +129,7 @@ class LibraryMigrationSuite extends AnyFunSuiteLike {
   }
 
   test("Formatting of valid Scala.js library") {
-    val migratedLib = LibraryMigration.migrateLib(domtypes)
+    val migratedLib = LibraryMigration.migrateLib(domtypes, defaultRepositories)
     val formatted   = migratedLib.formatted
     val expected    = s""""com.raquo" %%% "domtypes" % "0.14.3""""
     assert(formatted == expected)

--- a/migrate/src/test/scala/migrate/LibraryMigrationSuite.scala
+++ b/migrate/src/test/scala/migrate/LibraryMigrationSuite.scala
@@ -1,15 +1,15 @@
 package migrate
 
+import coursier.Repositories
+
 import scala.Console._
-import migrate.internal.{
-  CrossCompatibleLibrary,
-  CrossVersion,
-  IncompatibleLibrary,
-  InitialLib,
-  Repository,
-  UpdatedVersion,
-  ValidLibrary
-}
+import migrate.internal.CrossCompatibleLibrary
+import migrate.internal.CrossVersion
+import migrate.internal.IncompatibleLibrary
+import migrate.internal.InitialLib
+import migrate.internal.Repository
+import migrate.internal.UpdatedVersion
+import migrate.internal.ValidLibrary
 import org.scalatest.funsuite.AnyFunSuiteLike
 
 class LibraryMigrationSuite extends AnyFunSuiteLike {
@@ -34,7 +34,7 @@ class LibraryMigrationSuite extends AnyFunSuiteLike {
   val domtypes: InitialLib    = InitialLib("com.raquo:domtypes:0.14.3", binaryJs)
   val domutils: InitialLib    = InitialLib("com.raquo:domtestutils:0.14.7", binaryJs)
 
-  val defaultRepositories: Seq[Repository] = Seq(Repository("https://repo1.maven.org/maven2"))
+  val defaultRepositories: Seq[Repository] = Seq(Repository(Repositories.central.root))
 
   test("Integrated compiler plugin: kind projector") {
     val migrated  = LibraryMigration.migrateLib(kindProjector, defaultRepositories)

--- a/plugin/src/main/scala/migrate/LibsMigration.scala
+++ b/plugin/src/main/scala/migrate/LibsMigration.scala
@@ -27,10 +27,8 @@ private[migrate] object LibsMigration {
 
     val migrateAPI = ScalaMigratePlugin.getMigrateInstance(log)
 
-    // Convert sbt resolvers to coursier MavenRepositories
-    val mavenRepositories: Seq[coursierapi.MavenRepository] = resolvers.collect { case mvnRepo: sbt.librarymanagement.MavenRepository =>
-      coursierapi.MavenRepository.of(mvnRepo.root)
-    }
+    val mavenRepositories = resolvers.collect { case mvnRepo: sbt.librarymanagement.MavenRepository => mvnRepo.root }
+
     val migrated   = migrateAPI.migrateLibs(libraryDependencies.map(LibImpl.apply).asJava, mavenRepositories.asJava)
 
     val validLibs = migrated.getValidLibraries

--- a/plugin/src/main/scala/migrate/LibsMigration.scala
+++ b/plugin/src/main/scala/migrate/LibsMigration.scala
@@ -1,16 +1,16 @@
 package migrate
 
-import ScalaMigratePlugin.Keys.*
-import Messages.*
+import ScalaMigratePlugin.Keys._
+import Messages._
 import migrate.interfaces.{Lib, MigratedLib, MigratedLibs}
 import sbt.Keys
 import sbt.Def
 import sbt.MessageOnlyException
-import sbt.librarymanagement.{MavenRepository, Resolver}
+import sbt.librarymanagement.MavenRepository
 
-import scala.io.AnsiColor.*
+import scala.io.AnsiColor._
 import scala.util.{Failure, Success, Try}
-import scala.collection.JavaConverters.*
+import scala.collection.JavaConverters._
 
 private[migrate] object LibsMigration {
   val internalImpl = Def.task {
@@ -26,9 +26,7 @@ private[migrate] object LibsMigration {
     log.info(startingMessage(projectId))
 
     val migrateAPI = ScalaMigratePlugin.getMigrateInstance(log)
-
-    val mavenRepositories = resolvers.collect { case mvnRepo: sbt.librarymanagement.MavenRepository => mvnRepo.root }
-
+    val mavenRepositories = resolvers.collect { case mvnRepo: MavenRepository => mvnRepo.root }
     val migrated   = migrateAPI.migrateLibs(libraryDependencies.map(LibImpl.apply).asJava, mavenRepositories.asJava)
 
     val validLibs = migrated.getValidLibraries


### PR DESCRIPTION
The scala3 migration plugin gave a false suggestion for how to migrate Akka libraries. Instead of saying that the latest 2.9.4 version was a valid scala 3 library it suggested to downgrade to a version as early as 2.6.18 up to the version 2.9.0-M2. These version are the ones that are published to the maven central that this plugin are hard coded to. Later version of akka are published to https://repo.akka.io/maven.

This patch is using the configured repository in the sbt build to resolve the dependencies and are thereby able to find the correct versions.

Now:
```
sbt:test-project>  migrateDependencies test-project
[info] 
[info] Starting migration of libraries and compiler plugins in project 'test-project'
[info] 
[info] Valid dependencies:
...
[info] "com.typesafe.akka" %% "akka-cluster-typed" % "2.9.4"
...
```

Before this PR, older akka versions published to maven central was suggested by the migration tool
```
[warn] Versions to update:
...
[warn] "com.typesafe.akka" %% "akka-cluster-typed" % "2.6.17" (Other versions: 2.6.18, ..., 2.9.0-M2)
...

```